### PR TITLE
ignore download errors when LFS fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 build:
 	# https://developer.apple.com/documentation/xcode/building-swift-packages-or-apps-that-use-them-in-continuous-integration-workflows
 	# https://stackoverflow.com/questions/4969932/separate-build-directory-using-xcodebuild
+	# https://forums.swift.org/t/swiftpm-with-git-lfs/42396/4
+	GIT_LFS_SKIP_DOWNLOAD_ERRORS=1 \
 	xcodebuild \
 		-disableAutomaticPackageResolution \
 		-clonedSourcePackagesDirPath .swiftpm-packages \


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
Ignores LFS errors when cloning `mcap` as part of the build process.

**Description**
<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
Partially addresses https://github.com/foxglove/mcap/issues/734